### PR TITLE
fix: do not import rxjs using rxjs/Rx

### DIFF
--- a/src/interceptors/keycloak-bearer.interceptor.ts
+++ b/src/interceptors/keycloak-bearer.interceptor.ts
@@ -12,9 +12,10 @@ import {
   HttpEvent,
   HttpHeaders
 } from '@angular/common/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { Injectable } from '@angular/core';
 import { KeycloakService } from '../services';
+import 'rxjs/add/operator/mergeMap';
 
 /**
  * This interceptor includes the bearer by default in all HttpClient requests.

--- a/src/services/keycloak.service.ts
+++ b/src/services/keycloak.service.ts
@@ -9,7 +9,9 @@ import * as Keycloak from 'keycloak-js';
 import { Injectable } from '@angular/core';
 import { HttpHeaders } from '@angular/common/http';
 import { KeycloakConfig, KeycloakOptions } from '../interfaces';
-import { Observer, Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
+import { Observer } from 'rxjs/Observer';
+import 'rxjs/add/observable/create';
 
 /**
  * Service to expose existent methods from the Keycloak JS adapter, adding new


### PR DESCRIPTION
Using rxjs it's not a good idea to import from `rxjs/Rx` as this will import the entire rxjs library.