### PR TITLE
Add keycloak-authz and RPT Interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ There is also the possibility to exclude a list of URLs that should not have the
 } catch (error) {}
 ```
 
-## HttpClient RPT Interceptor with Entitlement API
+#### Entitlement API
 
 It is also possible to use the RPT interceptor with the Resource server which do not have UMA activated. Then the RPT Interceptor uses entitlement API to obtain RPT.
 
@@ -250,7 +250,7 @@ For example:
 } catch (error) {}
 ```
 
-## HttpClient RPT Interceptor with Authorization Request Template
+#### Authorization Request Template
 
 It is possible to specify additional parameters for all authorization requests as described in https://www.keycloak.org/docs/latest/authorization_services/index.html#authorization-request.
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ There is also the possibility to exclude a list of URLs that should not have the
 
 ## HttpClient RPT Interceptor
 
-It is possbile to activate RPT interceptor which adds RPT (requesting party token) to all HttpClient requests. Set `enableAuthorization` to true to enable the RPT Interceptor. The RPT will be added into Authorization header in the format of: Authorization: Bearer **_RPT_**. In this case the default can be deactivated by setting `bearerExcludedUrls` to exclude all paths.
+It is possbile to activate RPT interceptor which adds RPT (requesting party token) to all HttpClient requests. Set `enableAuthorization` to true to enable the RPT Interceptor. The RPT will be added into Authorization header in the format of: Authorization: Bearer **_RPT_**. In this case the bearer token interceptor can be deactivated by setting `bearerExcludedUrls` to exclude all paths (see example below).
 
 By default the RPT Interceptor uses the UMA (v2) API to support resource servers with UMA enabled policy enforcer. RPT Interceptor works with UMA 2 shipped with Keycloak 4.0.0 Beta1.
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,100 @@ There is also the possibility to exclude a list of URLs that should not have the
 } catch (error) {}
 ```
 
+## HttpClient RPT Interceptor
+
+It is possbile to activate RPT interceptor which adds RPT (requesting party token) to all HttpClient requests. Set `enableAuthorization` to true to enable the RPT Interceptor. The RPT will be added into Authorization header in the format of: Authorization: Bearer **_RPT_**. In this case the default can be deactivated by setting `bearerExcludedUrls` to exclude all paths.
+
+By default the RPT Interceptor uses the UMA (v2) API to support resource servers with UMA enabled policy enforcer. RPT Interceptor works with UMA 2 shipped with Keycloak 4.0.0 Beta1.
+
+There is also the possibility to exclude a list of URLs that should not have the RPT added (it probably makes sense to only add RPT token to HTTP requests sent to resource server and to exclude requests going to keycloak server). For example:
+
+```js
+ try {
+  await keycloak.init({
+    config: {
+      url: 'http://localhost:8080/auth',
+      realm: 'your-realm',
+      clientId: 'client-id'
+    },
+    initOptions: {
+      onLoad: 'login-required',
+      checkLoginIframe: false
+    },
+    bearerExcludedUrls: ["/"],
+    enableAuthorization: true,
+    rptExcludedUrls: ["/auth"]
+  });
+  resolve();
+} catch (error) {}
+```
+
+## HttpClient RPT Interceptor with Entitlement API
+
+It is also possible to use the RPT interceptor with the Resource server which do not have UMA activated. Then the RPT Interceptor uses entitlement API to obtain RPT.
+
+For example:
+
+```js
+ try {
+  await keycloak.init({
+    config: {
+      url: 'http://localhost:8080/auth',
+      realm: 'your-realm',
+      clientId: 'client-id'
+    },
+    initOptions: {
+      onLoad: 'login-required',
+      checkLoginIframe: false
+    },
+    bearerExcludedUrls: ["/"],
+    enableAuthorization: true,
+    rptExcludedUrls: ["/auth"],
+    resourceServerID: "resource-server-id",
+    resourceServerAuthorizationType: "entitlement"
+  });
+  resolve();
+} catch (error) {}
+```
+
+## HttpClient RPT Interceptor with Authorization Request Template
+
+It is possible to specify additional parameters for all authorization requests as described in https://www.keycloak.org/docs/latest/authorization_services/index.html#authorization-request.
+
+Note that UMA and Entitlement APIs support different parameters. 
+
+For example to reduce permissions in the RPT obtained from Entitlement API:
+
+```js
+ try {
+  await keycloak.init({
+    config: {
+      url: 'http://localhost:8080/auth',
+      realm: 'your-realm',
+      clientId: 'client-id'
+    },
+    initOptions: {
+      onLoad: 'login-required',
+      checkLoginIframe: false
+    },
+    bearerExcludedUrls: ["/"],
+    enableAuthorization: true,
+    rptExcludedUrls: ["/auth"],
+    resourceServerID: "resource-server-id",
+    resourceServerAuthorizationType: "entitlement",
+    authorizationRequestTemplate: {
+      permissions: [
+        {
+          id: 'Some Resource',
+          scopes: ['view', 'edit']
+        }
+      ]
+  }
+  });
+  resolve();
+} catch (error) {}
+```
+
 ## Contributing
 
 If you want to contribute to the project, please check out the [contributing](CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "copy-files":
       "npx shx mkdir -p ./build/keycloak-angular && npx shx cp -r {package.json,README.md,./src} ./build/keycloak-angular",
     "remove-unwanted-files":
-      "npx shx rm -rf {./build/**/*.ts,./build/keycloak-angular/test,./build/keycloak-angular/*.spec*}",
+    "npx shx rm -rf {./build/**/!(keycloak-authz.d).ts,./build/keycloak-angular/test,./build/keycloak-angular/*.spec*}",
     "compile": "npx ngc -p ./tsconfig.json",
     "build":
       "npm run clean && npm run copy-files && npm run remove-unwanted-files && npm run compile"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/mauriciovigolo/keycloak-angular#readme",
   "dependencies": {
-    "keycloak-js": "~3.4.3"
+    "keycloak-js": "^4.0.0-beta.1"
   },
   "devDependencies": {
     "@angular/common": "^4.4.6",

--- a/src/interceptors/index.ts
+++ b/src/interceptors/index.ts
@@ -6,3 +6,4 @@
  * found in the LICENSE file at https://github.org/mauriciovigolo/keycloak-angular/LICENSE
  */
 export * from './keycloak-bearer.interceptor';
+export * from './keycloak-rpt.interceptor';

--- a/src/interceptors/keycloak-rpt.interceptor.ts
+++ b/src/interceptors/keycloak-rpt.interceptor.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Mauricio Gemelli Vigolo and contributors.
+ * Copyright Swisscom (Schweiz) AG, Mauricio Gemelli Vigolo and contributors.
  *
  * Use of this source code is governed by a MIT-style license that can be
  * found in the LICENSE file at https://github.com/mauriciovigolo/keycloak-angular/LICENSE
@@ -54,7 +54,6 @@ export class KeycloakRptInterceptor implements HttpInterceptor {
    * @param next
    */
   public intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    console.log('KeycloakRptInterceptor');
 
     // If keycloak service is not initialized yet, or if authorization is not enabled or exclude URLs are not set
     if (
@@ -62,7 +61,6 @@ export class KeycloakRptInterceptor implements HttpInterceptor {
       !this.keycloak.isEnabledAuthorization ||
       !this.keycloak.getRptExcludedUrls()
     ) {
-      console.log('KeycloakRptInterceptor skip 1');
       return next.handle(req);
     }
 
@@ -74,7 +72,6 @@ export class KeycloakRptInterceptor implements HttpInterceptor {
 
     const shallPass: boolean = !!this.excludedUrlsRegex.find(regex => regex.test(urlRequest));
     if (shallPass) {
-      console.log('KeycloakRptInterceptor skip 2');
       return next.handle(req);
     }
 

--- a/src/interceptors/keycloak-rpt.interceptor.ts
+++ b/src/interceptors/keycloak-rpt.interceptor.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright Mauricio Gemelli Vigolo and contributors.
+ *
+ * Use of this source code is governed by a MIT-style license that can be
+ * found in the LICENSE file at https://github.com/mauriciovigolo/keycloak-angular/LICENSE
+ */
+import {
+  HttpInterceptor,
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpHeaders,
+  HttpErrorResponse
+} from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+import { Injectable } from '@angular/core';
+import { KeycloakService } from '../services';
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/observable/fromPromise';
+import 'rxjs/add/observable/of';
+import { Observer } from 'rxjs/Observer';
+
+import * as KeycloakAuthorization from '../keycloak-authz-js/keycloak-authz';
+
+/**
+ * This interceptor includes the RPT by default in all HttpClient requests.
+ *
+ * If you need to exclude some URLs from adding the rpt, please, take a look
+ * at the {@link KeycloakOptions} rptExcludedUrls property.
+ */
+@Injectable()
+export class KeycloakRptInterceptor implements HttpInterceptor {
+  private excludedUrlsRegex: RegExp[];
+
+  /**
+   * KeycloakRptInterceptor constructor.
+   *
+   * @param keycloak - Injected KeycloakService instance.
+   */
+  constructor(private keycloak: KeycloakService) {}
+
+  private loadExcludedUrlsRegex() {
+    const excludedUrls: string[] = this.keycloak.getRptExcludedUrls();
+    this.excludedUrlsRegex = excludedUrls.map(urlPattern => new RegExp(urlPattern, 'i')) || [];
+  }
+
+  /**
+   * Intercept implementation that checks if the request url matches the excludedUrls.
+   * If not, adds the Authorization header to the request.
+   *
+   * @param req
+   * @param next
+   */
+  public intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    console.log('KeycloakRptInterceptor');
+
+    // If keycloak service is not initialized yet, or if authorization is not enabled or exclude URLs are not set
+    if (
+      !this.keycloak ||
+      !this.keycloak.isEnabledAuthorization ||
+      !this.keycloak.getRptExcludedUrls()
+    ) {
+      console.log('KeycloakRptInterceptor skip 1');
+      return next.handle(req);
+    }
+
+    const urlRequest = req.url;
+
+    if (!this.excludedUrlsRegex) {
+      this.loadExcludedUrlsRegex();
+    }
+
+    const shallPass: boolean = !!this.excludedUrlsRegex.find(regex => regex.test(urlRequest));
+    if (shallPass) {
+      console.log('KeycloakRptInterceptor skip 2');
+      return next.handle(req);
+    }
+
+    // requests which have not been excluded will get RPT added or if no RPT was obtained until now, then the Access token is added
+
+    let headersWithRPTorAccessToken$: Observable<HttpHeaders>;
+
+    if (
+      this.keycloak.isEnabledAuthorization &&
+      this.keycloak.getKeycloakAuthorizationInstance() &&
+      this.keycloak.getRPT()
+    ) {
+      let headersWithRpt: HttpHeaders = this.keycloak.addRPTToHeader(req.headers);
+      headersWithRPTorAccessToken$ = Observable.of(headersWithRpt);
+    } else {
+      headersWithRPTorAccessToken$ = this.keycloak.addTokenToHeader(req.headers);
+    }
+
+    return headersWithRPTorAccessToken$.switchMap(headersWithRPTorAccessToken => {
+      const kcReq = req.clone({ headers: headersWithRPTorAccessToken });
+      return next.handle(kcReq).catch((error, caught) => {
+        // if error is with code 401 (Authorization error) and the www-authenticate is present
+        // or when entitlement API is to be used try to get valid RPT
+        if (this.isAuthError(error) && this.hasResponseWWWAuthenthicateHeader(error)
+        ) {
+          //make sure that the access token is fresh, a valid access token is needed to obtain an RPT
+          let updateTokenObservable = Observable.fromPromise(this.keycloak.updateToken(10));
+          return updateTokenObservable.switchMap(wasRefreshed => {
+            let wwwAuthenticateHeader = error.headers.get('www-authenticate');
+            let ticket = null;
+
+            // Handle Authorization Responses from a UMA-Protected Resource Server, entitlement api not implemented yet
+            if (wwwAuthenticateHeader.indexOf('UMA') != -1) {
+              // extract ticket parameter from www-authenticate header
+              var params = wwwAuthenticateHeader.split(',');
+              for (let i = 0; i < params.length; i++) {
+                var param = params[i].split('=');
+                if (param[0] == 'ticket') {
+                  ticket = param[1].substring(1, param[1].length - 1).trim();
+                }
+              }
+            }
+            // if failed to extract the ticket string
+            if (ticket == null) {
+              return Observable.throw(error);
+            }
+
+            //construct authorization request
+            let authorizationRequest: KeycloakAuthorization.KeycloakAuthorizationRequest = {
+              ...this.keycloak.getKeycloakAuthorizationInstance,
+              ticket
+            };
+
+            return this.getNewRPT(authorizationRequest)
+              .catch(e => {
+                return Observable.throw(error);
+              })
+              .switchMap(rpt => {
+                let headersWithRpt: HttpHeaders = this.keycloak.addRPTToHeader(req.headers);
+                const kcReq = req.clone({ headers: headersWithRpt });
+                return next.handle(kcReq);
+              });
+          });
+        } else {
+          return Observable.throw(error);
+        }
+      });
+    });
+  }
+
+  /**
+   * Wrapper for KeycloakAuhtorization.authrize() fucntion. Handles UMA authorization.
+   *
+   * @param req
+   * @param next
+   */
+  private getNewRPT(
+    authorizationRequest: KeycloakAuthorization.KeycloakAuthorizationRequest
+  ): Observable<string> {
+    var authz = this.keycloak.getKeycloakAuthorizationInstance();
+
+    return Observable.create(async (observer: Observer<any>) => {
+      try {
+            authz.authorize(authorizationRequest).then(
+              rpt => {
+                observer.next(rpt);
+                observer.complete();
+              },
+              () => {
+                observer.error('Authorization request was denied by the server.');
+              },
+              () => {
+                observer.error('Could not obtain authorization data from server.');
+              }
+            );        
+      } catch (error) {
+        observer.error(error);
+      }
+    });
+  }
+
+  private isAuthError(error: any): boolean {
+    return error instanceof HttpErrorResponse && error.status === 401;
+  }
+
+  private hasResponseWWWAuthenthicateHeader(error: any): boolean {
+    return error instanceof HttpErrorResponse && error.headers.has('www-authenticate');
+  }
+
+  private getAndApplyRPTToken(error: any): boolean {
+    return error instanceof HttpErrorResponse && error.status === 401;
+  }
+}

--- a/src/interceptors/keycloak-rpt.interceptor.ts
+++ b/src/interceptors/keycloak-rpt.interceptor.ts
@@ -94,7 +94,7 @@ export class KeycloakRptInterceptor implements HttpInterceptor {
       const kcReq = req.clone({ headers: headersWithRPTorAccessToken });
       return next.handle(kcReq).catch((error, caught) => {
         // if error is with code 401 (Authorization error) and the www-authenticate is present try to get valid RPT
-        if (this.isAuthError(error) && this.hasResponseWWWAuthenthicateHeader(error)) {
+        if (this.isAuthError(error) && this.hasResponseWWWAuthenthicateHeader(error) && this.keycloak.getResourceServerAuthorizationType() == 'uma') {
           //make sure that the access token is fresh, a valid access token is needed to obtain an RPT
           let updateTokenObservable = Observable.fromPromise(this.keycloak.updateToken(10));
           return updateTokenObservable.switchMap(wasRefreshed => {
@@ -113,7 +113,7 @@ export class KeycloakRptInterceptor implements HttpInterceptor {
               }
             }
             // if failed to extract the ticket string
-            if (ticket == null && this.keycloak.getResourceServerAuthorizationType() == 'uma') {
+            if (ticket == null) {
               return Observable.throw(error);
             }
 

--- a/src/interfaces/keycloak-init-options.ts
+++ b/src/interfaces/keycloak-init-options.ts
@@ -50,7 +50,7 @@ export interface KeycloakInitOptions {
    * Set the interval to check login state (in seconds).
    * @default 5
    */
-  checkLoginIframeInterval?: boolean;
+  checkLoginIframeInterval?: number;
   /**
    * Set the OpenID Connect response mode to send to Keycloak upon login.
    * @default fragment After successful authentication Keycloak will redirect

--- a/src/interfaces/keycloak-options.ts
+++ b/src/interfaces/keycloak-options.ts
@@ -42,4 +42,26 @@ export interface KeycloakOptions {
    * Default is false.
    */
   enableAuthorization?: boolean;
+  /**
+   * Object with following optional keys: permissions, ticket, submitRequest, metadata, incrementalAuthorization.
+   * Server as a template for an Authroization Request consumed by functions
+   * KeycloakAuthorizationInstance.authorize() and KeycloakAuthorizationInstance.entitlement().
+   */
+  authorizationRequestTemplate?: {
+    permissions?: any;
+    ticket?: any;
+    submitRequest?: any;
+    metadata?: any;
+    incrementalAuthorization?: any;
+  };
+  /**
+   * String "uma" or "entitlement" specifies, which function of the two functions
+   * KeycloakAuthorizationInstance.authorize() or KeycloakAuthorizationInstance.entitlement()
+   * will be used to obtain RPT. When not set, UMA is used.
+   */
+  resourceServerAuthorizationType?: string;
+  /**
+   * Resource server ID, only needed when resourceServerAuthorizationType is set to "entitlement";
+   */
+  resourceServerID?: string;
 }

--- a/src/interfaces/keycloak-options.ts
+++ b/src/interfaces/keycloak-options.ts
@@ -31,4 +31,15 @@ export interface KeycloakOptions {
    * token to the request.
    */
   bearerExcludedUrls?: string[];
+  /**
+   * String Array to exclude the urls that should not have the Authorization Header automatically
+   * added. This library makes use of Angular Http Interceptor, to automatically add the RPT
+   * token to the request. Here you should exclude urls which do not go to your resource server.
+   */
+  rptExcludedUrls?: string[];
+  /**
+   * If true, the KeycloakAuthorization is initialized and KeycloakRptInterceptor is activated.
+   * Default is false.
+   */
+  enableAuthorization?: boolean;
 }

--- a/src/keycloak-angular.module.ts
+++ b/src/keycloak-angular.module.ts
@@ -7,7 +7,7 @@
  */
 import { NgModule } from '@angular/core';
 import { KeycloakService } from './services';
-import { KeycloakBearerInterceptor } from './interceptors';
+import { KeycloakBearerInterceptor, KeycloakRptInterceptor } from './interceptors';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 /**
@@ -21,6 +21,11 @@ import { HTTP_INTERCEPTORS } from '@angular/common/http';
     {
       provide: HTTP_INTERCEPTORS,
       useClass: KeycloakBearerInterceptor,
+      multi: true
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: KeycloakRptInterceptor,
       multi: true
     }
   ]

--- a/src/keycloak-authz-js/keycloak-authz.d.ts
+++ b/src/keycloak-authz-js/keycloak-authz.d.ts
@@ -1,0 +1,59 @@
+/*
+ * MIT License
+ *
+ * Copyright 2017 Brett Epps <https://github.com/eppsilon>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import * as Keycloak from 'keycloak';
+
+export as namespace KeycloakAuthorization;
+
+export = KeycloakAuthorization;
+
+/**
+ * Creates a new Keycloak client instance.
+ * @param config Path to a JSON config file or a plain config object.
+ */
+declare function KeycloakAuthorization(keycloak: Keycloak.KeycloakInstance): KeycloakAuthorization.KeycloakAuthorizationInstance;
+
+declare namespace KeycloakAuthorization {
+	interface KeycloakAuthorizationPromise {
+		then(onGrant: (rpt: string) => void, onDeny: () => void, onError: () => void): void;
+	}
+
+	interface KeycloakAuthorizationInstance {
+		rpt: any;
+		config: { rpt_endpoint: string };
+
+		init(): void;
+
+		/**
+		 * This method enables client applications to better integrate with resource servers protected by a Keycloak
+		 * policy enforcer.
+		 *
+		 * In this case, the resource server will respond with a 401 status code and a WWW-Authenticate header holding the
+		 * necessary information to ask a Keycloak server for authorization data using both UMA and Entitlement protocol,
+		 * depending on how the policy enforcer at the resource server was configured.
+		 */
+		authorize(wwwAuthenticateHeader: string): KeycloakAuthorizationPromise;
+
+		/**
+		 * Obtains all entitlements from a Keycloak server based on a given resourceServerId.
+		 */
+		entitlement(resourceServerId: string, entitlementRequest: {}): KeycloakAuthorizationPromise;
+	}
+}

--- a/src/keycloak-authz-js/keycloak-authz.d.ts
+++ b/src/keycloak-authz-js/keycloak-authz.d.ts
@@ -18,7 +18,7 @@
  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import * as Keycloak from 'keycloak';
+import * as Keycloak from 'keycloak-js';
 
 export as namespace KeycloakAuthorization;
 
@@ -35,6 +35,14 @@ declare namespace KeycloakAuthorization {
 		then(onGrant: (rpt: string) => void, onDeny: () => void, onError: () => void): void;
 	}
 
+	interface KeycloakAuthorizationRequest {
+		permissions?:any,
+		ticket?:any,
+		submitRequest?:any,
+		metadata?:any,
+		incrementalAuthorization?:any
+	}
+
 	interface KeycloakAuthorizationInstance {
 		rpt: any;
 		config: { rpt_endpoint: string };
@@ -49,7 +57,7 @@ declare namespace KeycloakAuthorization {
 		 * necessary information to ask a Keycloak server for authorization data using both UMA and Entitlement protocol,
 		 * depending on how the policy enforcer at the resource server was configured.
 		 */
-		authorize(wwwAuthenticateHeader: string): KeycloakAuthorizationPromise;
+		authorize(wwwAuthenticateHeader: KeycloakAuthorizationRequest): KeycloakAuthorizationPromise;
 
 		/**
 		 * Obtains all entitlements from a Keycloak server based on a given resourceServerId.

--- a/src/keycloak-authz-js/keycloak-authz.js
+++ b/src/keycloak-authz-js/keycloak-authz.js
@@ -1,0 +1,219 @@
+/*
+ *  Copyright 2016 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+(function( window, undefined ) {
+
+    var KeycloakAuthorization = function (keycloak, options) {
+        var _instance = this;
+        this.rpt = null;
+
+        this.init = function () {
+            var request = new XMLHttpRequest();
+
+            request.open('GET', keycloak.authServerUrl + '/realms/' + keycloak.realm + '/.well-known/uma2-configuration');
+            request.onreadystatechange = function () {
+                if (request.readyState == 4) {
+                    if (request.status == 200) {
+                        _instance.config = JSON.parse(request.responseText);
+                    } else {
+                        console.error('Could not obtain configuration from server.');
+                    }
+                }
+            }
+
+            request.send(null);
+        };
+
+        /**
+         * This method enables client applications to better integrate with resource servers protected by a Keycloak
+         * policy enforcer.
+         *
+         * In this case, the resource server will respond with a 401 status code and a WWW-Authenticate header holding the
+         * necessary information to ask a Keycloak server for authorization data using both UMA and Entitlement protocol,
+         * depending on how the policy enforcer at the resource server was configured.
+         */
+        this.authorize = function (authorizationRequest) {
+            this.then = function (onGrant, onDeny, onError) {
+                if (authorizationRequest && authorizationRequest.ticket) {
+                    var request = new XMLHttpRequest();
+
+                    request.open('POST', _instance.config.token_endpoint, true);
+                    request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+                    request.setRequestHeader('Authorization', 'Bearer ' + keycloak.token);
+
+                    request.onreadystatechange = function () {
+                        if (request.readyState == 4) {
+                            var status = request.status;
+
+                            if (status >= 200 && status < 300) {
+                                var rpt = JSON.parse(request.responseText).access_token;
+                                _instance.rpt = rpt;
+                                onGrant(rpt);
+                            } else if (status == 403) {
+                                if (onDeny) {
+                                    onDeny();
+                                } else {
+                                    console.error('Authorization request was denied by the server.');
+                                }
+                            } else {
+                                if (onError) {
+                                    onError();
+                                } else {
+                                    console.error('Could not obtain authorization data from server.');
+                                }
+                            }
+                        }
+                    };
+
+                    var params = "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&client_id=" + keycloak.clientId + "&ticket=" + authorizationRequest.ticket;
+
+                    if (authorizationRequest.submitRequest != undefined) {
+                        params += "&submit_request=" + authorizationRequest.submitRequest;
+                    }
+
+                    var metadata = authorizationRequest.metadata;
+
+                    if (metadata) {
+                        if (metadata.responseIncludeResourceName) {
+                            params += "&response_include_resource_name=" + metadata.responseIncludeResourceName;
+                        }
+                        if (metadata.responsePermissionsLimit) {
+                            params += "&response_permissions_limit=" + metadata.responsePermissionsLimit;
+                        }
+                    }
+
+                    if (_instance.rpt && (authorizationRequest.incrementalAuthorization == undefined || authorizationRequest.incrementalAuthorization)) {
+                        params += "&rpt=" + _instance.rpt;
+                    }
+
+                    request.send(params);
+                }
+            };
+
+            return this;
+        };
+
+        /**
+         * Obtains all entitlements from a Keycloak Server based on a given resourceServerId.
+         */
+        this.entitlement = function (resourceServerId, authorizationRequest) {
+            this.then = function (onGrant, onDeny, onError) {
+                var request = new XMLHttpRequest();
+
+                request.open('POST', _instance.config.token_endpoint, true);
+                request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+                request.setRequestHeader('Authorization', 'Bearer ' + keycloak.token);
+
+                request.onreadystatechange = function () {
+                    if (request.readyState == 4) {
+                        var status = request.status;
+
+                        if (status >= 200 && status < 300) {
+                            var rpt = JSON.parse(request.responseText).access_token;
+                            _instance.rpt = rpt;
+                            onGrant(rpt);
+                        } else if (status == 403) {
+                            if (onDeny) {
+                                onDeny();
+                            } else {
+                                console.error('Authorization request was denied by the server.');
+                            }
+                        } else {
+                            if (onError) {
+                                onError();
+                            } else {
+                                console.error('Could not obtain authorization data from server.');
+                            }
+                        }
+                    }
+                };
+
+                if (!authorizationRequest) {
+                    authorizationRequest = {};
+                }
+
+                var params = "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&client_id=" + keycloak.clientId;
+
+                if (authorizationRequest.claimToken) {
+                    params += "&claim_token=" + authorizationRequest.claimToken;
+
+                    if (authorizationRequest.claimTokenFormat) {
+                        params += "&claim_token_format=" + authorizationRequest.claimTokenFormat;
+                    }
+                }
+
+                params += "&audience=" + resourceServerId;
+
+                var permissions = authorizationRequest.permissions;
+
+                if (!permissions) {
+                    permissions = [];
+                }
+
+                for (i = 0; i < permissions.length; i++) {
+                    var resource = permissions[i];
+                    var permission = resource.id;
+
+                    if (resource.scopes && resource.scopes.length > 0) {
+                        permission += "#";
+                        for (j = 0; j < resource.scopes.length; j++) {
+                            var scope = resource.scopes[j];
+                            if (permission.indexOf('#') != permission.length - 1) {
+                                permission += ",";
+                            }
+                            permission += scope;
+                        }
+                    }
+
+                    params += "&permission=" + permission;
+                }
+
+                var metadata = authorizationRequest.metadata;
+
+                if (metadata) {
+                    if (metadata.responseIncludeResourceName) {
+                        params += "&response_include_resource_name=" + metadata.responseIncludeResourceName;
+                    }
+                    if (metadata.responsePermissionsLimit) {
+                        params += "&response_permissions_limit=" + metadata.responsePermissionsLimit;
+                    }
+                }
+
+                if (_instance.rpt) {
+                    params += "&rpt=" + _instance.rpt;
+                }
+
+                request.send(params);
+            };
+
+            return this;
+        };
+
+        this.init(this);
+    };
+
+    if ( typeof module === "object" && module && typeof module.exports === "object" ) {
+        module.exports = KeycloakAuthorization;
+    } else {
+        window.KeycloakAuthorization = KeycloakAuthorization;
+
+        if ( typeof define === "function" && define.amd ) {
+            define( "keycloak-authorization", [], function () { return KeycloakAuthorization; } );
+        }
+    }
+})( window );

--- a/src/keycloak-authz-js/keycloak-authz.js
+++ b/src/keycloak-authz-js/keycloak-authz.js
@@ -1,6 +1,8 @@
 /*
  *  Copyright 2016 Red Hat, Inc. and/or its affiliates
  *  and other contributors as indicated by the @author tags.
+ * 
+ *  Modifications copyright (C) 2018 Swisscom (Schweiz) AG
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,6 +17,8 @@
  *  limitations under the License.
  *
  */
+
+
 
 (function( window, undefined ) {
 

--- a/src/keycloak-authz-js/keycloak-authz.js
+++ b/src/keycloak-authz-js/keycloak-authz.js
@@ -205,6 +205,7 @@
         };
 
         this.init(this);
+        return this;
     };
 
     if ( typeof module === "object" && module && typeof module.exports === "object" ) {

--- a/src/services/keycloak.service.ts
+++ b/src/services/keycloak.service.ts
@@ -80,6 +80,13 @@ export class KeycloakService {
         .success(async authenticated => {
           if (this._isEnabledAuthorization) {
             this.authzInstance = KeycloakAuthorization(this.instance);
+            this.authorizationRequestTemplate = options.authorizationRequestTemplate || {};
+            this.resourceServerAuthorizationType = options.resourceServerAuthorizationType || "uma";
+            this.resourceServerAuthorizationType=this.resourceServerAuthorizationType.toLowerCase();
+            if(this.resourceServerAuthorizationType!=="uma" && this.resourceServerAuthorizationType!=="entitlement"){
+              options.resourceServerAuthorizationType="uma";
+            }
+            this.resourceServerID=options.resourceServerID || "";
           }
           if (authenticated) {
             await this.loadUserProfile();
@@ -426,4 +433,26 @@ export class KeycloakService {
   get isEnabledAuthorization(): boolean {
     return this._isEnabledAuthorization;
   }
+  /**
+   * Returns the excluded URLs that should not be considered by
+   * the RPT http interceptor which automatically adds the authorization header in the Http Request.
+   */
+  getAuthorizationRequestTemplate(): {
+    permissions?: any;
+    ticket?: any;
+    submitRequest?: any;
+    metadata?: any;
+    incrementalAuthorization?: any;
+  } {
+    return this.authorizationRequestTemplate;
+  }
+
+  getResourceServerAuthorizationType(): string{
+    return this.resourceServerAuthorizationType;
+  };
+  
+  getResourceServerID(): string{
+    return this.resourceServerID;
+  };
+
 }


### PR DESCRIPTION
Add support for automatic obtaining of RPT (requesting party token) from keycloak server and attaching the RPT to HTTP requests which are sent to the resource server. 