### PR TITLE
RPT Interceptor for Keycloak 4.0.0 Final and Angular 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,102 @@ There is also the possibility to exclude a list of URLs that should not have the
 } catch (error) {}
 ```
 
+## HttpClient RPT Interceptor
+
+It is possbile to activate RPT interceptor which adds RPT (requesting party token) to all HttpClient requests. Set `enableRPTInterceptor` to true to enable the RPT Interceptor. The RPT will be added into Authorization header in the format of: Authorization: Bearer **_RPT_**. In this case the bearer token interceptor can be deactivated by setting `bearerExcludedUrls` to exclude all paths (see example below).
+
+By default the RPT Interceptor uses the UMA (v2) API to support resource servers with UMA enabled policy enforcer. RPT Interceptor works with UMA 2 shipped with Keycloak 4.0.0 Beta1.
+
+There is also the possibility to exclude a list of URLs that should not have the RPT added (it probably makes sense to only add RPT token to HTTP requests sent to resource server and to exclude requests going to keycloak server). For example:
+
+```js
+ try {
+  await keycloak.init({
+    config: {
+      url: 'http://localhost:8080/auth',
+      realm: 'your-realm',
+      clientId: 'client-id'
+    },
+    initOptions: {
+      onLoad: 'login-required',
+      checkLoginIframe: false
+    },
+    bearerExcludedUrls: ["/"],
+    enableRPTInterceptor: true,
+    rptExcludedUrls: ["/auth"]
+  });
+  resolve();
+} catch (error) {}
+```
+
+#### Entitlement API
+
+It is also possible to use the RPT interceptor with the Resource server which do not have UMA activated. Then the RPT Interceptor uses entitlement API to obtain RPT.
+
+For example:
+
+```js
+ try {
+  await keycloak.init({
+    config: {
+      url: 'http://localhost:8080/auth',
+      realm: 'your-realm',
+      clientId: 'client-id'
+    },
+    initOptions: {
+      onLoad: 'login-required',
+      checkLoginIframe: false
+    },
+    bearerExcludedUrls: ["/"],
+    enableRPTInterceptor: true,
+    rptExcludedUrls: ["/auth"],
+    resourceServerID: "resource-server-id",
+    resourceServerAuthorizationType: "entitlement"
+  });
+  resolve();
+} catch (error) {}
+```
+
+#### Authorization Request Template
+
+It is possible to specify additional parameters for all authorization requests as described in https://www.keycloak.org/docs/latest/authorization_services/index.html#authorization-request.
+
+Note that UMA and Entitlement APIs support different parameters.
+
+For example to reduce permissions in the RPT obtained from Entitlement API and to
+keep incrementing RPT (might be more useful when combined with UMA):
+
+```js
+ try {
+  await keycloak.init({
+    config: {
+      url: 'http://localhost:8080/auth',
+      realm: 'your-realm',
+      clientId: 'client-id'
+    },
+    initOptions: {
+      onLoad: 'login-required',
+      checkLoginIframe: false
+    },
+    bearerExcludedUrls: ["/"],
+    enableRPTInterceptor: true,
+    rptExcludedUrls: ["/auth"],
+    resourceServerID: "resource-server-id",
+    resourceServerAuthorizationType: "entitlement",
+    authorizationRequestTemplate: {
+      permissions: [
+        {
+          id: 'Some Resource',
+          scopes: ['view', 'edit']
+        }
+      ],
+      incrementalAuthorization:true
+  }
+  });
+  resolve();
+} catch (error) {}
+```
+
 ## Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/projects/keycloak-angular/src/lib/core/core.module.ts
+++ b/projects/keycloak-angular/src/lib/core/core.module.ts
@@ -12,6 +12,7 @@ import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { KeycloakService } from './services/keycloak.service';
 import { KeycloakBearerInterceptor } from './interceptors/keycloak-bearer.interceptor';
+import { KeycloakRptInterceptor } from './interceptors/keycloak-rpt.interceptor';
 
 @NgModule({
   imports: [CommonModule],
@@ -20,6 +21,11 @@ import { KeycloakBearerInterceptor } from './interceptors/keycloak-bearer.interc
     {
       provide: HTTP_INTERCEPTORS,
       useClass: KeycloakBearerInterceptor,
+      multi: true
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: KeycloakRptInterceptor,
       multi: true
     }
   ]

--- a/projects/keycloak-angular/src/lib/core/interceptors/keycloak-rpt.interceptor.ts
+++ b/projects/keycloak-angular/src/lib/core/interceptors/keycloak-rpt.interceptor.ts
@@ -1,0 +1,227 @@
+/**
+ * @license
+ * Copyright Mauricio Gemelli Vigolo and contributors.
+ *
+ * Use of this source code is governed by a MIT-style license that can be
+ * found in the LICENSE file at https://github.com/mauriciovigolo/keycloak-angular/LICENSE
+ */
+
+import { Injectable } from '@angular/core';
+import {
+  HttpInterceptor,
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpHeaders,
+  HttpErrorResponse
+} from '@angular/common/http';
+
+import { Observable, from as fromPromise, Observer, of } from 'rxjs';
+import { mergeMap, switchMap, catchError } from 'rxjs/operators';
+
+import { KeycloakService } from '../services/keycloak.service';
+
+/**
+ * This interceptor includes the bearer by default in all HttpClient requests.
+ *
+ * If you need to exclude some URLs from adding the bearer, please, take a look
+ * at the {@link KeycloakOptions} bearerExcludedUrls property.
+ */
+@Injectable()
+export class KeycloakRptInterceptor implements HttpInterceptor {
+  private excludedUrlsRegex: RegExp[];
+
+  /**
+   * KeycloakBearerInterceptor constructor.
+   *
+   * @param keycloak - Injected KeycloakService instance.
+   */
+  constructor(private keycloak: KeycloakService) {}
+
+  private loadExcludedUrlsRegex() {
+    const excludedUrls: string[] = this.keycloak.rptExcludedUrls;
+    this.excludedUrlsRegex = excludedUrls.map(urlPattern => new RegExp(urlPattern, 'i')) || [];
+  }
+
+  /**
+   * Intercept implementation that checks if the request url matches the excludedUrls.
+   * If not, adds the Authorization header to the request.
+   *
+   * @param req
+   * @param next
+   */
+  public intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    // If keycloak service is not initialized yet, or if authorization is not enabled or exclude URLs are not set
+    if (!this.keycloak || !this.keycloak.isEnableRPTInterceptor || !this.keycloak.rptExcludedUrls) {
+      return next.handle(req);
+    }
+
+    const urlRequest = req.url;
+    if (!this.excludedUrlsRegex) {
+      this.loadExcludedUrlsRegex();
+    }
+
+    const shallPass: boolean = !!this.excludedUrlsRegex.find(regex => regex.test(urlRequest));
+    if (shallPass) {
+      return next.handle(req);
+    }
+
+    let headersWithRPTorAccessToken$: Observable<HttpHeaders>;
+
+    // requests which have not been excluded will get RPT added or if no RPT was obtained until now, then the Access token is added
+    if (
+      this.keycloak.isEnableRPTInterceptor &&
+      this.keycloak.keycloakAuthorizationInstance &&
+      this.keycloak.RPT
+    ) {
+      //if RPT already was loaded, then add RPT
+      let headersWithRpt: HttpHeaders = this.keycloak.addRPTToHeader(req.headers);
+      // make an observable out of headersWithRpt, this is just for convenience:
+      // addTokenToHeader() returns observable but addRPTToHeader() is a simple function,
+      // making result of addRPTToHeader() to an observable allows me to have the same flow
+      // after this if-else regardless if RPT or access token was added to headers
+      headersWithRPTorAccessToken$ = of(headersWithRpt);
+    } else {
+      //if there is no RPT yet, then add the access token
+      headersWithRPTorAccessToken$ = this.keycloak.addTokenToHeader(req.headers);
+    }
+
+    return headersWithRPTorAccessToken$.pipe(
+      switchMap(headersWithRPTorAccessToken => {
+        // send out the request with added RPT or Access Token
+        const kcReq = req.clone({ headers: headersWithRPTorAccessToken });
+        return next.handle(kcReq);
+      }),
+      catchError((error, caught) => {
+        // if error is with code 401 (Authorization error), the www-authenticate is present, and
+        // resourceServerAuthorizationType is 'uma'
+        // we can try to get valid RPT based on the authorization ticket which we received in the
+        // response (it is inside www-authenticate response header)
+        if (
+          this.isAuthError(error) &&
+          this.hasResponseWWWAuthenthicateHeader(error) &&
+          this.keycloak.resourceServerAuthorizationType == 'uma'
+        ) {
+          //make sure that the access token is fresh, a valid access token is needed to obtain an RPT
+          let updateTokenObservable = fromPromise(this.keycloak.updateToken(10));
+          return updateTokenObservable.pipe(
+            switchMap(wasRefreshed => {
+              let wwwAuthenticateHeader = error.headers.get('www-authenticate');
+              let ticket = null;
+
+              // Handle Authorization Responses from a UMA-Protected Resource Server
+              if (wwwAuthenticateHeader.indexOf('UMA') != -1) {
+                // extract ticket parameter from www-authenticate header
+                var params = wwwAuthenticateHeader.split(',');
+                for (let i = 0; i < params.length; i++) {
+                  var param = params[i].split('=');
+                  if (param[0] == 'ticket') {
+                    ticket = param[1].substring(1, param[1].length - 1).trim();
+                  }
+                }
+              }
+              // if failed to extract the ticket string
+              if (ticket == null) {
+                return Observable.throw(error);
+              }
+              //construct authorization request
+              let authorizationRequest: KeycloakAuthorization.AuthorizationRequest = {
+                ...this.keycloak.authorizationRequestTemplate,
+                ticket
+              };
+              return this.getNewRPT(authorizationRequest).pipe(
+                catchError(e => {
+                  return Observable.throw(error);
+                }),
+                switchMap(rpt => {
+                  let headersWithRpt: HttpHeaders = this.keycloak.addRPTToHeader(req.headers);
+                  const kcReq: HttpRequest<any> = req.clone({ headers: headersWithRpt });
+                  return next.handle(kcReq);
+                })
+              );
+            })
+          );
+          // when entitlement API is to be used try to get valid RPT
+        } else if (this.keycloak.resourceServerAuthorizationType == 'entitlement') {
+          //construct authorization request
+          let authorizationRequest: KeycloakAuthorization.AuthorizationRequest = this.keycloak
+            .authorizationRequestTemplate;
+          return this.getNewRPT(authorizationRequest).pipe(
+            catchError(e => {
+              return Observable.throw(error);
+            }),
+            switchMap(rpt => {
+              let headersWithRpt: HttpHeaders = this.keycloak.addRPTToHeader(req.headers);
+              const kcReq: HttpRequest<any> = req.clone({ headers: headersWithRpt });
+              return next.handle(kcReq);
+            })
+          );
+        } else {
+          return Observable.throw(error);
+        }
+      })
+    );
+  }
+
+  /**
+   * Wrapper for KeycloakAuhtorization.authrize() fucntion. Handles UMA and entitlement API authorization.
+   *
+   * @param req
+   * @param next
+   */
+  private getNewRPT(
+    authorizationRequest: KeycloakAuthorization.AuthorizationRequest
+  ): Observable<string> {
+    var authz = this.keycloak.keycloakAuthorizationInstance;
+
+    return Observable.create(async (observer: Observer<any>) => {
+      try {
+        if (this.keycloak.resourceServerAuthorizationType == 'entitlement') {
+          authz.entitlement(this.keycloak.resourceServerID, authorizationRequest).then(
+            rpt => {
+              this.keycloak.RPTupdateEmitter.next(rpt);
+              observer.next(rpt);
+              observer.complete();
+            },
+            () => {
+              observer.error('Authorization request was denied by the server.');
+            },
+            () => {
+              observer.error('Could not obtain authorization data from server.');
+            }
+          );
+        } else {
+          if (this.keycloak.resourceServerAuthorizationType == 'uma') {
+            authz.authorize(authorizationRequest).then(
+              rpt => {
+                this.keycloak.RPTupdateEmitter.next(rpt);
+                observer.next(rpt);
+                observer.complete();
+              },
+              () => {
+                observer.error('Authorization request was denied by the server.');
+              },
+              () => {
+                observer.error('Could not obtain authorization data from server.');
+              }
+            );
+          }
+        }
+      } catch (error) {
+        observer.error(error);
+      }
+    });
+  }
+
+  private isAuthError(error: any): boolean {
+    return error instanceof HttpErrorResponse && error.status === 401;
+  }
+
+  private hasResponseWWWAuthenthicateHeader(error: any): boolean {
+    return error instanceof HttpErrorResponse && error.headers.has('www-authenticate');
+  }
+
+  private getAndApplyRPTToken(error: any): boolean {
+    return error instanceof HttpErrorResponse && error.status === 401;
+  }
+}

--- a/projects/keycloak-angular/src/lib/core/interceptors/keycloak-rpt.interceptor.ts
+++ b/projects/keycloak-angular/src/lib/core/interceptors/keycloak-rpt.interceptor.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Mauricio Gemelli Vigolo and contributors.
+ * Copyright Marcel Német and contributors.
  *
  * Use of this source code is governed by a MIT-style license that can be
  * found in the LICENSE file at https://github.com/mauriciovigolo/keycloak-angular/LICENSE

--- a/projects/keycloak-angular/src/lib/core/interceptors/keycloak-rpt.interceptor.ts
+++ b/projects/keycloak-angular/src/lib/core/interceptors/keycloak-rpt.interceptor.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Marcel Német and contributors.
+ * Copyright Swisscom (Schweiz) AG and contributors.
  *
  * Use of this source code is governed by a MIT-style license that can be
  * found in the LICENSE file at https://github.com/mauriciovigolo/keycloak-angular/LICENSE

--- a/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
+++ b/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
@@ -8,6 +8,7 @@
 
 import { KeycloakInitOptions } from './keycloak-init-options';
 import { KeycloakConfig } from './keycloak-config';
+import { AuthorizationRequest } from 'keycloak-js/dist/keycloak-authz';
 
 /**
  * keycloak-angular initialization options.
@@ -68,4 +69,32 @@ export interface KeycloakOptions {
    * Warning: this value must be in compliance with the keycloak server instance and the adapter.
    */
   bearerPrefix?: string;
+  /**
+   * String Array to exclude the urls that should not have the RPT Authorization Header automatically
+   * added. This library makes use of Angular Http Interceptor, to automatically add the RPT
+   * token to the request. Here you should exclude urls which do not go to your resource server.
+   *
+   */
+  rptExcludedUrls?: string[];
+  /**
+   * If true, the KeycloakAuthorization is initialized and KeycloakRptInterceptor is activated.
+   * Default is false.
+   */
+  enableRPTInterceptor?: boolean;
+  /**
+   * Serves as a template for an Authroization Request consumed by functions
+   * KeycloakAuthorizationInstance.authorize() and KeycloakAuthorizationInstance.entitlement().
+   * see KeycloakAuthorization.AuthorizationRequest documentation for the format.
+   */
+  authorizationRequestTemplate?: AuthorizationRequest;
+  /**
+   * String "uma" or "entitlement" specifies, which function of the two functions
+   * KeycloakAuthorizationInstance.authorize() or KeycloakAuthorizationInstance.entitlement()
+   * will be used to obtain RPT. When not set, UMA is used.
+   */
+  resourceServerAuthorizationType?: string;
+  /**
+   * Resource server ID, only needed when resourceServerAuthorizationType is set to "entitlement";
+   */
+  resourceServerID?: string;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/master/docs/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, the keycloak-angular library does not support authorization features of Keycloak. It only supports the authentication.

Issue Number: 32

## What is the new behavior?
RPT HTTP interceptor has been added. It can be enabled to intercept HTTP requests, obtain a new access token from Keycloak server with necessary permissions to access a resource and resend the request with the new access token.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_overview
https://www.keycloak.org/docs/latest/authorization_services/index.html#handling-authorization-responses-from-a-uma-protected-resource-server
https://www.keycloak.org/docs/latest/authorization_services/index.html#obtaining-entitlements

