### PR TITLE
feat(packaging): update keycloak-js to v7.0.1

### DIFF
--- a/examples/webapp/keycloak-heroes-bootstrap/package.json
+++ b/examples/webapp/keycloak-heroes-bootstrap/package.json
@@ -28,7 +28,7 @@
     "@webcomponents/custom-elements": "^1.2.4",
     "core-js": "^3.1.4",
     "keycloak-angular": "^7.0.1",
-    "keycloak-js": "^6.0.1",
+    "keycloak-js": "^7.0.1",
     "rxjs": "^6.4.0",
     "zone.js": "^0.9.1"
   },

--- a/examples/webapp/keycloak-heroes/package.json
+++ b/examples/webapp/keycloak-heroes/package.json
@@ -28,7 +28,7 @@
     "@webcomponents/custom-elements": "^1.2.4",
     "core-js": "^3.1.4",
     "keycloak-angular": "^7.0.1",
-    "keycloak-js": "^6.0.1",
+    "keycloak-js": "^7.0.1",
     "rxjs": "^6.4.0",
     "zone.js": "^0.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
-    "keycloak-js": "^6.0.1",
+    "keycloak-js": "^7.0.1",
     "ng-packagr": "^5.3.0",
     "protractor": "~5.4.0",
     "rxjs": "~6.4.0",

--- a/projects/keycloak-angular/package.json
+++ b/projects/keycloak-angular/package.json
@@ -34,6 +34,6 @@
     "@angular/common": ">= 4.3.0 < 9",
     "@angular/core": ">= 4.3.0 < 9",
     "@angular/router": ">= 4.3.0 < 9",
-    "keycloak-js": ">= 3.4.3 < 7"
+    "keycloak-js": ">= 3.4.3 < 8"
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/master/docs/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Uses `keycloak-js` version 6.0.1

## What is the new behavior?

Uses `keycloak-js` version 7.0.1

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
See the [Keycloak release](https://www.keycloak.org/docs/latest/release_notes/index.html#keycloak-7-0-1) notes for more information.

This change should ensure that NPM no longer issues a warning about `keycloak-js` with version 7 or greater (see below).

> npm WARN keycloak-angular@7.0.1 requires a peer of keycloak-js@>= 3.4.3 < 7 but none is installed. You must install peer dependencies yourself.