### PR TITLE
fix: add UrlTree return type to KeycloakAuthGuard

### DIFF
--- a/projects/keycloak-angular/src/lib/core/services/keycloak-auth-guard.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak-auth-guard.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://github.com/mauriciovigolo/keycloak-angular/LICENSE
  */
 
-import { CanActivate, Router, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { CanActivate, Router, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
 
 import { KeycloakService } from './keycloak.service';
 
@@ -35,7 +35,7 @@ export abstract class KeycloakAuthGuard implements CanActivate {
    * @param route
    * @param state
    */
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean | UrlTree> {
     return new Promise(async (resolve, reject) => {
       try {
         this.authenticated = await this.keycloakAngular.isLoggedIn();
@@ -53,11 +53,13 @@ export abstract class KeycloakAuthGuard implements CanActivate {
    * Create your own customized authorization flow in this method. From here you already known
    * if the user is authenticated (this.authenticated) and the user roles (this.roles).
    *
+   * Return a UrlTree if the user should be redirected to another route.
+   *
    * @param route
    * @param state
    */
   abstract isAccessAllowed(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
-  ): Promise<boolean>;
+  ): Promise<boolean | UrlTree>;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [X] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/master/docs/CONTRIBUTING.md)
*that link returns a 404*
* [X] Tests for the changes have been added (for bug fixes / features)
*Only typing was added*
* [X] Docs have been added / updated (for bug fixes / features)
*This is documented by the CanActivate of Angular*

## PR Type

What kind of change does this PR introduce?

```
[X] Bugfix
```

## What is the current behavior?

The KeycloakAuthGuard cannot redirect.

## What is the new behavior?

The KeycloakAuthGuard can redirect.

## Does this PR introduce a breaking change?

```
[X] No
```

## Other information

https://blog.angularindepth.com/new-in-angular-v7-1-updates-to-the-router-fd67d526ad05
https://blog.ninja-squad.com/2018/11/22/what-is-new-angular-7.1/