### PR TITLE
refactor: remove deprecated KeycloakInitOptions alias from public API

### DIFF
--- a/projects/keycloak-angular/src/public_api.ts
+++ b/projects/keycloak-angular/src/public_api.ts
@@ -11,10 +11,6 @@ export {
   KeycloakEvent,
   KeycloakEventType
 } from './lib/core/interfaces/keycloak-event';
-/**
- * @deprecated Use Keycloak's internal types instead.
- */
-export type KeycloakInitOptions = Keycloak.KeycloakInitOptions;
 export { KeycloakOptions } from './lib/core/interfaces/keycloak-options';
 export { KeycloakAuthGuard } from './lib/core/services/keycloak-auth-guard';
 export { KeycloakService } from './lib/core/services/keycloak.service';


### PR DESCRIPTION
Closes #181.

## Migration
From
```
import { KeycloakInitOptions } from 'keycloak-angular';
```

To
```
import { KeycloakInitOptions } from 'keycloak';
```