### PR TITLE
Drop support for versions of Angular below 10

### DIFF
--- a/projects/keycloak-angular/package.json
+++ b/projects/keycloak-angular/package.json
@@ -26,9 +26,9 @@
     "oidc"
   ],
   "peerDependencies": {
-    "@angular/common": ">= 8.0.0 < 11",
-    "@angular/core": ">= 8.0.0 < 11",
-    "@angular/router": ">= 8.0.0 < 11",
+    "@angular/common": "^10",
+    "@angular/core": "^10",
+    "@angular/router": "^10",
     "keycloak-js": ">= 3.4.3 < 7 || > 7 < 11"
   },
   "dependencies": {


### PR DESCRIPTION
Since we cannot reliably support multiple versions of Angular we will support Angular 10 in version 8 of Keycloak Angular whilst at the same time dropping support for older versions. If you need to support an older version of Angular it's recommended to use an older version of Keycloak Angular.