### PR TITLE
Use a capitalized bearer prefix of 'Bearer' instead of 'bearer' by default

### DIFF
--- a/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
+++ b/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
@@ -105,9 +105,10 @@ export interface KeycloakOptions {
   authorizationHeaderName?: string;
   /**
    * This value will be included in the Authorization Http Header param. The default value is
-   * **bearer**, which will result in a Http Header Authorization as "Authorization: bearer <token>".
+   * **Bearer**, which will result in a Http Header Authorization as "Authorization: Bearer <token>".
+   *
    * If any other value is needed by the backend in the authorization header, you should change this
-   * value, i.e: **Bearer**.
+   * value.
    *
    * Warning: this value must be in compliance with the keycloak server instance and the adapter.
    */

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
@@ -159,7 +159,7 @@ export class KeycloakService {
     loadUserProfileAtStartUp = true,
     bearerExcludedUrls = [],
     authorizationHeaderName = 'Authorization',
-    bearerPrefix = 'bearer',
+    bearerPrefix = 'Bearer',
     initOptions,
   }: KeycloakOptions): void {
     this._enableBearerInterceptor = enableBearerInterceptor;


### PR DESCRIPTION
Closes #217