### PR TITLE
Do not load user profile at startup

### DIFF
--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
@@ -156,7 +156,7 @@ export class KeycloakService {
    */
   private initServiceValues({
     enableBearerInterceptor = true,
-    loadUserProfileAtStartUp = true,
+    loadUserProfileAtStartUp = false,
     bearerExcludedUrls = [],
     authorizationHeaderName = 'Authorization',
     bearerPrefix = 'bearer',


### PR DESCRIPTION
To make sure that first time users do not run in to trouble when they do not allow `view-profile` access in their client explicitly we should not attempt to load the user profile at startup,