### PR TITLE
Add kc login options to init

### DIFF
--- a/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
+++ b/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://github.com/mauriciovigolo/keycloak-angular/LICENSE
  */
 
+import {KeycloakLoginOptions} from 'keycloak-js';
+
 /**
  * HTTP Methods
  */
@@ -111,4 +113,8 @@ export interface KeycloakOptions {
    * Warning: this value must be in compliance with the keycloak server instance and the adapter.
    */
   bearerPrefix?: string;
+  /**
+   * A way to provide keycloak login options during initialization.
+   */
+  keycloakLoginOptions?: KeycloakLoginOptions;
 }

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
@@ -221,9 +221,9 @@ export class KeycloakService {
 
     if (this._keycloakLoginOptions !== null) {
       const kcLogin = this._instance.login;
-      this._instance.login = (options: KeycloakLoginOptions): any => {
-        Object.assign(options, this._keycloakLoginOptions);
-        kcLogin(options);
+      this._instance.login = (keycloakLoginOptions: KeycloakLoginOptions): any => {
+        Object.assign(keycloakLoginOptions, this._keycloakLoginOptions);
+        kcLogin(keycloakLoginOptions);
       };
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/master/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Unable to pass login options on init of KeycloakService.

Issue Number: #334 

## What is the new behavior?

Allow for passing in KeycloakLoginOptions as part of KeycloakOptions which get passed into the init method.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
