### PR TITLE
refactor: define public keycloakEvents$ as Observable instead of Subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ await keycloak.init({
 
 ## Keycloak-js Events
 
-The callback events from [keycloak-js](https://www.keycloak.org/docs/latest/securing_apps/index.html#javascript-adapter-reference) are available through a RxJS subject which is defined by `keycloakEvents$`.
+The callback events from [keycloak-js](https://www.keycloak.org/docs/latest/securing_apps/index.html#javascript-adapter-reference) are available through a RxJS observable which is defined by `keycloakEvents$`.
 
 For example you make keycloak-angular auto refreshing your access token when expired:
 

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
@@ -546,7 +546,5 @@ export class KeycloakService {
    * A subject with the {@link KeycloakEvent} which describes the event type and attaches the
    * function args.
    */
-  get keycloakEvents$(): Subject<KeycloakEvent> {
-    return this._keycloakEvents$;
-  }
+  public readonly keycloakEvents$: Observable<KeycloakEvent> = this._keycloakEvents$.asObservable();
 }


### PR DESCRIPTION
`keycloakEvents$` should be used to **listen** to events. With the current definition, One could also **send** events. Subjects should never be public.

In the old implementation, there is no difference between the public `keycloakEvents$` and the private `_keycloakEvents$`

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/master/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
