### PR TITLE
fix: modify updateToken so it does not swallow errors

### DIFF
--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
@@ -77,5 +77,14 @@ describe('KeycloakService', () => {
         expect(token).toEqual('testToken');
       }
     ));
+
+    it('should throw error if updateToken is called before initialization', inject(
+      [KeycloakService],
+      async (service: KeycloakService) => {
+        await expectAsync(service.updateToken()).toBeRejectedWithError(
+          /not initialized/
+        );
+      }
+    ));
   });
 });

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
@@ -398,23 +398,23 @@ export class KeycloakService {
    * Promise with a boolean indicating if the token was succesfully updated.
    */
   public async updateToken(minValidity = this._updateMinValidity) {
+    // TODO: this is a workaround until the silent refresh (issue #43)
+    // is not implemented, avoiding the redirect loop.
+    if (this._silentRefresh) {
+      if (this.isTokenExpired()) {
+        throw new Error(
+          'Failed to refresh the token, or the session is expired'
+        );
+      }
+
+      return true;
+    }
+
+    if (!this._instance) {
+      throw new Error('Keycloak Angular library is not initialized.');
+    }
+
     try {
-      // TODO: this is a workaround until the silent refresh (issue #43)
-      // is not implemented, avoiding the redirect loop.
-      if (this._silentRefresh) {
-        if (this.isTokenExpired()) {
-          throw new Error(
-            'Failed to refresh the token, or the session is expired'
-          );
-        }
-
-        return true;
-      }
-
-      if (!this._instance) {
-        throw new Error('Keycloak Angular library is not initialized.');
-      }
-
       return await this._instance.updateToken(minValidity);
     } catch (error) {
       return false;


### PR DESCRIPTION
Fixes #433. Reverts regression introduced with #412.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: added test case
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Errors thrown in `updateToken` are silently ignored.

Issue Number: #433

## What is the new behavior?

Errors thrown in `updateToken` can be handled outside the method.

## Does this PR introduce a breaking change?


```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
