### PR TITLE
feat: Add support for bearerIncludedUrls (#121)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@
 root = true
 
 [*]
+max_line_length = 80
 charset = utf-8
 indent_style = space
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -232,12 +232,29 @@ await keycloak.init({
     silentCheckSsoRedirectUri:
       window.location.origin + '/assets/silent-check-sso.html'
   },
-  bearerExcludedUrls: ['/assets', '/clients/public'],
   shouldUpdateToken: (request) => {
     return !request.headers.get('token-update') === 'false';
   }
 });
 ```
+
+By default, the interceptor add a bearer token to all http requests. 
+You can configure the interceptor to only add a bearer token for certain urls by setting the `bearerIncludedUrls` property:
+```ts
+await keycloak.init({
+  config: {...},
+  bearerIncludedUrls: ['/api/needs-token'],
+});
+```
+
+Alternatively, you can configure the interceptor to exclude urls by setting the `bearerExcludedUrls` property:
+```ts
+await keycloak.init({
+  config: {...},
+  bearerExcludedUrls: ['/assets', '/clients/public'],
+});
+```
+_Note: `bearerExcludedUrls` is deprecated and will be removed in a future release!_
 
 ## Keycloak-js Events
 

--- a/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
+++ b/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
@@ -38,7 +38,7 @@ export type HttpMethods =
  * If the url is informed but httpMethod is undefined, then the bearer
  * will not be added for all HTTP Methods.
  */
-export interface ExcludedUrl {
+export interface UrlAndHttpMethods {
   url: string;
   httpMethods?: HttpMethods[];
 }
@@ -48,7 +48,7 @@ export interface ExcludedUrl {
  * include the url patterns.
  * This interface is used internally by the KeycloakService.
  */
-export interface ExcludedUrlRegex {
+export interface UrlRegex {
   urlPattern: RegExp;
   httpMethods?: HttpMethods[];
 }
@@ -90,13 +90,22 @@ export interface KeycloakOptions {
    * The default value is true.
    */
   loadUserProfileAtStartUp?: boolean;
+
   /**
    * @deprecated
-   * String Array to exclude the urls that should not have the Authorization Header automatically
+   * Array to exclude the urls that should not have the Authorization Header automatically
    * added. This library makes use of Angular Http Interceptor, to automatically add the Bearer
    * token to the request.
    */
-  bearerExcludedUrls?: (string | ExcludedUrl)[];
+  bearerExcludedUrls?: (string | UrlAndHttpMethods)[];
+
+  /**
+   * Array to include the urls that should have the Authorization Header automatically
+   * added. This library makes use of Angular Http Interceptor, to automatically add the Bearer
+   * token to the request.
+   */
+  bearerIncludedUrls?: (string | UrlAndHttpMethods)[];
+
   /**
    * This value will be used as the Authorization Http Header name. The default value is
    * **Authorization**. If the backend expects requests to have a token in a different header, you

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
@@ -24,26 +24,30 @@ describe('KeycloakService', () => {
     }
   ));
 
-  describe('#loadExcludedUrls', () => {
-    it('should create the ExcludedUrlRegex objects if the bearerExcludedUrls arg is a string array', inject(
+  describe('#transformToUrlRegexes', () => {
+    it('should create the UrlRegex objects if the bearerExcludedUrls arg is a string array', inject(
       [KeycloakService],
       (service: KeycloakService) => {
-        const loadExcludedUrls = service['loadExcludedUrls'];
-        const result = loadExcludedUrls(['home', 'public']);
+        const transformToUrlRegexes = service['transformToUrlRegexes'];
+        const result = transformToUrlRegexes(['home', 'public']);
         const { urlPattern, httpMethods } = result[0];
 
         expect(result.length).toBe(2);
         expect(urlPattern).toBeDefined();
         expect(urlPattern.test('http://url/home')).toBeTruthy();
-        expect(httpMethods.length).toBe(0);
+        expect(urlPattern.test('http://home/url')).toBeTruthy();
+        expect(urlPattern.test('/home')).toBeTruthy();
+        expect(urlPattern.test('/hotel')).toBeFalse();
+
+        expect(httpMethods).toBe(undefined);
       }
     ));
 
-    it('should create the ExcludedUrlRegex objects if the bearerExcludedUrls arg is an mixed array of strings and ExcludedUrl objects', inject(
+    it('should create the UrlRegex objects if the bearerExcludedUrls arg is an mixed array of strings and UrlAndHttpMethods objects', inject(
       [KeycloakService],
       (service: KeycloakService) => {
-        const loadExcludedUrls = service['loadExcludedUrls'];
-        const result = loadExcludedUrls([
+        const transformToUrlRegexes = service['transformToUrlRegexes'];
+        const result = transformToUrlRegexes([
           'home',
           { url: 'public', httpMethods: ['GET'] }
         ]);
@@ -52,7 +56,7 @@ describe('KeycloakService', () => {
         const excludedRegex1 = result[0];
         expect(excludedRegex1.urlPattern).toBeDefined();
         expect(excludedRegex1.urlPattern.test('https://url/home')).toBeTruthy();
-        expect(excludedRegex1.httpMethods.length).toBe(0);
+        expect(excludedRegex1.httpMethods).toBe(undefined);
 
         const excludedRegex2 = result[1];
         expect(excludedRegex2.urlPattern).toBeDefined();
@@ -83,6 +87,20 @@ describe('KeycloakService', () => {
       async (service: KeycloakService) => {
         await expectAsync(service.updateToken()).toBeRejectedWithError(
           /not initialized/
+        );
+      }
+    ));
+
+    it(`should throw an error if both 'bearerExcludedUrls' and 'bearerIncludedUrls' are set`, inject(
+      [KeycloakService],
+      async (service: KeycloakService) => {
+        await expectAsync(
+          service.init({
+            bearerIncludedUrls: ['/api'],
+            bearerExcludedUrls: ['/hi']
+          })
+        ).toBeRejectedWithError(
+          `'bearerExcludedUrls' and 'bearerIncludedUrls' are both set, aborting initialisation: You can only use one or the other.`
         );
       }
     ));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no support for an allow list for the interceptor that adds the bearer token to api calls. 

Issue Number: #121

## What is the new behavior?
Add support for `bearerIncludedUrls`, while keeping backwards compatibility enabled with `bearerExcludedUrls`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
