### PR TITLE
Enforce LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,11 +3,12 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
+end_of_line = lf
 indent_size = 2
+indent_style = space
 insert_final_newline = true
-trim_trailing_whitespace = true
 quote_type=single
+trim_trailing_whitespace = true
 
 [*.md]
 max_line_length = off

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
On Windows `autocrlf` is `true` by default. This ensures that line endings are always LF and fixes prettier issues on Windows.

---

## PR Checklist

Please check if your PR fulfills the following requirements:

* [ ] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[X] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
