### PR TITLE
refactor: change return types for some functions in KeycloakService since they are not asynchronous anymore

### DIFF
--- a/projects/example/src/app/app.component.html
+++ b/projects/example/src/app/app.component.html
@@ -1,6 +1,9 @@
 <h1>Keycloak Angular Example</h1>
 
-<button *ngIf="isLoggedIn" type="button" (click)="logout()">Log out</button>
+<ng-container *ngIf="isLoggedIn">
+  <button type="button" (click)="logout()">Log out</button>
+  <button type="button" (click)="updateToken()" style="margin-left: 4px;">Update token</button>
+</ng-container>
 <button *ngIf="!isLoggedIn" type="button" (click)="login()">Log in</button>
 
 <ng-container *ngIf="userProfile">

--- a/projects/example/src/app/app.component.ts
+++ b/projects/example/src/app/app.component.ts
@@ -14,7 +14,7 @@ export class AppComponent implements OnInit {
   constructor(private readonly keycloak: KeycloakService) {}
 
   public async ngOnInit() {
-    this.isLoggedIn = await this.keycloak.isLoggedIn();
+    this.isLoggedIn = this.keycloak.isLoggedIn();
 
     if (this.isLoggedIn) {
       this.userProfile = await this.keycloak.loadUserProfile();
@@ -27,5 +27,9 @@ export class AppComponent implements OnInit {
 
   public logout() {
     this.keycloak.logout();
+  }
+
+  public async updateToken(): Promise<void> {
+    await this.keycloak.updateToken(-1);
   }
 }

--- a/projects/keycloak-angular/src/lib/core/services/keycloak-auth-guard.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak-auth-guard.ts
@@ -49,8 +49,8 @@ export abstract class KeycloakAuthGuard implements CanActivate {
     state: RouterStateSnapshot
   ): Promise<boolean | UrlTree> {
     try {
-      this.authenticated = await this.keycloakAngular.isLoggedIn();
-      this.roles = await this.keycloakAngular.getUserRoles(true);
+      this.authenticated = this.keycloakAngular.isLoggedIn();
+      this.roles = this.keycloakAngular.getUserRoles(true);
 
       return await this.isAccessAllowed(route, state);
     } catch (error) {

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
@@ -72,7 +72,7 @@ describe('KeycloakService', () => {
           token: 'testToken'
         };
 
-        const token = await service.getToken();
+        const token = service.getToken();
 
         expect(token).toEqual('testToken');
       }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Functions `isLoggedIn`, `getToken` and `addTokenToHeader` in `KeycloakService` are defined as asynchronous.

In the old versions of the library, all these functions have side effect - they called `updateToken`. In the latest versions this side effect has been removed, but the functions are still defined as asynchronous, but they are not.
It might be helpful, for example, when someone migrates from some old version and notices that functions do not return promise/observable anymore, and it clearly tells that no asynchronous calls to update token will be done.

## What is the new behavior?

Functions are defined as synchronous (do not return promise or observable).

P.S. I have also added a small feature to the showcase app: a new button that allows to get a new token from Keycloak. It might be helpful to test the library behavior when token is expired. But I am not sure that it is necessary for everyone, maybe it is better to keep the showcase app as simple as it is possible. Let me know, please, and I will remove the feature.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
