### PR TITLE
feature: Add resource filter to KeycloakService#getUserRoles()

### DIFF
--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
@@ -8,6 +8,8 @@
 
 import { TestBed, inject } from '@angular/core/testing';
 
+import Keycloak from 'keycloak-js';
+
 import { KeycloakService } from './keycloak.service';
 
 describe('KeycloakService', () => {
@@ -83,6 +85,125 @@ describe('KeycloakService', () => {
       async (service: KeycloakService) => {
         await expectAsync(service.updateToken()).toBeRejectedWithError(
           /not initialized/
+        );
+      }
+    ));
+  });
+
+  describe('#getUserRoles', () => {
+    it('should return all resource and realm roles', inject(
+      [KeycloakService],
+      async (service: KeycloakService) => {
+        (service['_instance'] as Partial<Keycloak>) = {
+          resourceAccess: {
+            client1: {
+              roles: ['client1Role1', 'client1Role2']
+            },
+            client2: {
+              roles: ['client2Role1', 'client2Role2']
+            }
+          },
+          realmAccess: {
+            roles: ['realmRole1', 'realmRole2']
+          }
+        };
+
+        const userRoles = service.getUserRoles();
+
+        expect(userRoles).toEqual(
+          jasmine.arrayWithExactContents([
+            'client1Role1',
+            'client1Role2',
+            'client2Role1',
+            'client2Role2',
+            'realmRole1',
+            'realmRole2'
+          ])
+        );
+      }
+    ));
+
+    it('should return only resource roles if realmRoles is set to false', inject(
+      [KeycloakService],
+      async (service: KeycloakService) => {
+        (service['_instance'] as Partial<Keycloak>) = {
+          resourceAccess: {
+            client1: {
+              roles: ['client1Role1', 'client1Role2']
+            },
+            client2: {
+              roles: ['client2Role1', 'client2Role2']
+            }
+          },
+          realmAccess: {
+            roles: ['realmRole1', 'realmRole2']
+          }
+        };
+
+        const userRoles = service.getUserRoles(false);
+
+        expect(userRoles).toEqual(
+          jasmine.arrayWithExactContents([
+            'client1Role1',
+            'client1Role2',
+            'client2Role1',
+            'client2Role2'
+          ])
+        );
+      }
+    ));
+
+    it('should return only resource roles from the given resource if realmRoles is set to false and resource is specified', inject(
+      [KeycloakService],
+      async (service: KeycloakService) => {
+        (service['_instance'] as Partial<Keycloak>) = {
+          resourceAccess: {
+            client1: {
+              roles: ['client1Role1', 'client1Role2']
+            },
+            client2: {
+              roles: ['client2Role1', 'client2Role2']
+            }
+          },
+          realmAccess: {
+            roles: ['realmRole1', 'realmRole2']
+          }
+        };
+
+        const userRoles = service.getUserRoles(false, 'client2');
+
+        expect(userRoles).toEqual(
+          jasmine.arrayWithExactContents(['client2Role1', 'client2Role2'])
+        );
+      }
+    ));
+
+    it('should return only resource roles from the given resource and realm roles if realmRoles is set to true and resource is specified', inject(
+      [KeycloakService],
+      async (service: KeycloakService) => {
+        (service['_instance'] as Partial<Keycloak>) = {
+          resourceAccess: {
+            client1: {
+              roles: ['client1Role1', 'client1Role2']
+            },
+            client2: {
+              roles: ['client2Role1', 'client2Role2']
+            }
+          },
+          realmAccess: {
+            roles: ['realmRole1', 'realmRole2']
+          }
+        };
+
+        const userRoles = service.getUserRoles(true, 'client1');
+
+        expect(userRoles).toEqual(
+          jasmine.arrayWithExactContents([
+            'client1Role1',
+            'client1Role2',
+            'realmRole1',
+            'realmRole2'
+          ])
         );
       }
     ));

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
@@ -70,7 +70,7 @@ describe('KeycloakService', () => {
       [KeycloakService],
       async (service: KeycloakService) => {
         service.updateToken = () => Promise.resolve(true);
-        (service['_instance'] as any) = {
+        (service['_instance'] as Partial<Keycloak>) = {
           token: 'testToken'
         };
 

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
@@ -313,12 +313,12 @@ export class KeycloakService {
 
   /**
    * Check if the user has access to the specified role. It will look for roles in
-   * realm and clientId, but will not check if the user is logged in for better performance.
+   * realm and the given resource, but will not check if the user is logged in for better performance.
    *
    * @param role
    * role name
    * @param resource
-   * resource name If not specified, `clientId` is used
+   * resource name. If not specified, `clientId` is used
    * @returns
    * A boolean meaning if the user has the specified Role.
    */

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.ts
@@ -332,27 +332,32 @@ export class KeycloakService {
   }
 
   /**
-   * Return the roles of the logged user. The allRoles parameter, with default value
-   * true, will return the clientId and realm roles associated with the logged user. If set to false
-   * it will only return the user roles associated with the clientId.
+   * Return the roles of the logged user. The realmRoles parameter, with default value
+   * true, will return the resource roles and realm roles associated with the logged user. If set to false
+   * it will only return the resource roles. The resource parameter, if specified, will return only resource roles
+   * associated with the given resource.
    *
-   * @param allRoles
-   * Flag to set if all roles should be returned.(Optional: default value is true)
+   * @param realmRoles
+   * Set to false to exclude realm roles (only client roles)
+   * @param resource
+   * resource name If not specified, returns roles from all resources
    * @returns
    * Array of Roles associated with the logged user.
    */
-  getUserRoles(allRoles: boolean = true): string[] {
+  getUserRoles(realmRoles: boolean = true, resource?: string): string[] {
     let roles: string[] = [];
     if (this._instance.resourceAccess) {
       for (const key in this._instance.resourceAccess) {
         if (this._instance.resourceAccess.hasOwnProperty(key)) {
-          const resourceAccess = this._instance.resourceAccess[key];
-          const clientRoles = resourceAccess['roles'] || [];
-          roles = roles.concat(clientRoles);
+          if (!resource || resource == key) {
+            const resourceAccess = this._instance.resourceAccess[key];
+            const clientRoles = resourceAccess['roles'] || [];
+            roles = roles.concat(clientRoles);
+          }
         }
       }
     }
-    if (allRoles && this._instance.realmAccess) {
+    if (realmRoles && this._instance.realmAccess) {
       const realmRoles = this._instance.realmAccess['roles'] || [];
       roles.push(...realmRoles);
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #522

## What is the new behavior?

Added a new `resource` parameter to `KeycloakService#getUserRoles()`.

This parameter can be used to filter resource roles by a resource (usually `clientId`).

If the parameter is not specified, the function returns all resource roles, as-per the current behavior, to avoid any breaking changes.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
