### PR TITLE
feat: add option to automatically refresh token on getToken()

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,25 @@ await keycloak.init({
 });
 ```
 
+You may also opt to have keycloak attempt to refresh the token when getToken() is called. This is useful if you do not want to use the `keycloakEvents$` RxJS subject and do not use Angular's HTTP module (For example, if you use Axios). This is set to `true` by default, so it's not necessary to pass this value to the initializer. You may, however, set this to `false` to disable the automatic refresh, should you chose.
+
+```ts
+await keycloak.init({
+  config: {
+    url: 'http://localhost:8080',
+    realm: 'your-realm',
+    clientId: 'your-client-id'
+  },
+  initOptions: {
+    onLoad: 'check-sso',
+    silentCheckSsoRedirectUri:
+      window.location.origin + '/assets/silent-check-sso.html'
+  },
+  bearerExcludedUrls: ['/assets', '/clients/public'],
+  refreshOnGet: true
+});
+```
+
 ## Keycloak-js Events
 
 The callback events from [keycloak-js](https://www.keycloak.org/docs/latest/securing_apps/index.html#javascript-adapter-reference) are available through a RxJS subject which is defined by `keycloakEvents$`.

--- a/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
+++ b/projects/keycloak-angular/src/lib/core/interfaces/keycloak-options.ts
@@ -121,6 +121,16 @@ export interface KeycloakOptions {
    * The default value is 20.
    */
   updateMinValidity?: number;
+
+  /**
+   * This value determines whether or not a token will be refreshed when `getToken()` is called. If the
+   * value is `true`, then the token's expiry time will be checked when `getToken()` is called, and
+   * if it is less than the number of seconds configured by updateMinValidity, then it will be updated
+   * before the token is returned.
+   *
+   * The default is true.
+   */
+  refreshOnGet?: boolean;
   /**
    * A function that will tell the KeycloakBearerInterceptor whether to add the token to the request
    * or to leave the request as it is. If the returned value is `true`, the request will have the token

--- a/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
+++ b/projects/keycloak-angular/src/lib/core/services/keycloak.service.spec.ts
@@ -70,6 +70,7 @@ describe('KeycloakService', () => {
       [KeycloakService],
       async (service: KeycloakService) => {
         service.updateToken = () => Promise.resolve(true);
+        service.isTokenExpired = () => false;
         (service['_instance'] as Partial<Keycloak>) = {
           token: 'testToken'
         };
@@ -77,6 +78,27 @@ describe('KeycloakService', () => {
         const token = await service.getToken();
 
         expect(token).toEqual('testToken');
+      }
+    ));
+
+    it('should return an updated token when getToken is called', inject(
+      [KeycloakService],
+      async (service: KeycloakService) => {
+        service.updateToken = () => {
+          (service['_instance'] as Partial<Keycloak>) = {
+            token: 'newToken'
+          };
+          return Promise.resolve(true);
+        };
+        service.isTokenExpired = () => true;
+        service['_refreshOnGet'] = true;
+        (service['_instance'] as Partial<Keycloak>) = {
+          token: 'oldToken'
+        };
+
+        const token = await service.getToken();
+
+        expect(token).toEqual('newToken');
       }
     ));
 


### PR DESCRIPTION
The JSDoc states that getToken() calls updateToken() if necessary, however this never happens. An option has been added that automatically refreshes the token when getToken() is called. By default this is true. This allows devs to not have to rely on the RxJS Subject or the HttpAdapter, if they chose not to use Angular's HTTP module (For example, if they use Axios instead).

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #531 describes the current behavior that is being fixed

## What is the new behavior?
keycloak-angular will now attempt to refresh the token when `getToken()` is called if it is A) expired, and B) `refreshOnGet` is set to `true`. By default, this value is true, however, developers may opt to disable this functionality by setting `refreshOnGet` to `false`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
`getToken()` now takes an optional `minValidity` similar to other keycloak-angular methods, which allows the developer to specify a `minValidity` value directly from the `getToken()` call instead of having to call `updateToken()` with a `minValidity` prior to calling `getToken()`