### PR TITLE
Proposition: don't wait for Keycloak's initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 
 function initializeKeycloak(keycloak: KeycloakService) {
-  return () =>
+  return () => {
     keycloak.init({
       config: {
         url: 'http://localhost:8080',
@@ -91,6 +91,7 @@ function initializeKeycloak(keycloak: KeycloakService) {
           window.location.origin + '/assets/silent-check-sso.html'
       }
     });
+  }
 }
 
 @NgModule({
@@ -189,7 +190,7 @@ By default, all HttpClient requests will add the Authorization header in the for
 There is also the possibility to exclude requests that should not have the authorization header. This is accomplished by implementing the `shouldAddToken` method in the keycloak initialization. For example, the configuration below will not add the token to `GET` requests that match the paths `/assets` or `/clients/public`:
 
 ```ts
-await keycloak.init({
+keycloak.init({
   config: {
     url: 'http://localhost:8080',
     realm: 'your-realm',
@@ -219,7 +220,7 @@ In the case where your application frequently polls an authenticated endpoint, y
 In the example below, any http requests with the header `token-update: false` will not trigger the user's keycloak token to be updated.
 
 ```ts
-await keycloak.init({
+keycloak.init({
   config: {
     url: 'http://localhost:8080',
     realm: 'your-realm',

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ In the example we have set up Keycloak to use a silent `check-sso`. With this fe
 
 To ensure that Keycloak can communicate through the iframe you will have to serve a static HTML asset from your application at the location provided in `silentCheckSsoRedirectUri`.
 
+If your app should be accessible only to authorized users, then set `onLoad: 'login-required'` and `await keycloak.init()`.
+
 Create a file called `silent-check-sso.html` in the `assets` directory of your application and paste in the contents as seen below.
 
 ```html


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [X] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features)
* [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Improved setup instructions. 
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently if 3rd party cookies are disabled (e.g. on Safari) when opening Keycloak-secured app using 'check-sso' on load, app initialization NEVER completes when `silentCheckSsoFallback` is turned off or redirects user to login page (which can be just an "Invalid credentials" error page when login+password login is disabled) and he can never go back, because of this immediate redirect.

There's an underlaying issue in `keycloak-js`, which doesn't handle failed `GET /realms/${realmName}/protocol/openid-connect/auth` request correctly, just silences it.

Issue Number: #544

## What is the new behavior?
App doesn't wait for Keycloak initialization, so it doesn't break, but it may not be a proper solution when using `onLoad: 'login-required'

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Screen recording of described behaviors
<a href="https://youtu.be/esSa5MDf6Ps" target="_blank">
<img width="781" alt="image" src="https://github.com/mauriciovigolo/keycloak-angular/assets/8938562/4b9d0873-942b-4bb3-ae54-7d2e0e2a6796"></a>
