### PR TITLE
fix: add missing intercept import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ import {
   provideKeycloak,
   createInterceptorCondition,
   IncludeBearerTokenCondition,
+  includeBearerTokenInterceptor,
   INCLUDE_BEARER_TOKEN_INTERCEPTOR_CONFIG
 } from 'keycloak-angular';
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Main README is missing an import statement for `includeBearerTokenInterceptor`.

Issue Number: N/A

## What is the new behavior?

Missing import is added

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```
