### PR TITLE
docs(legacy): fix incorrect migration guide URL

### DIFF
--- a/projects/keycloak-angular/src/lib/legacy/core/core.module.ts
+++ b/projects/keycloak-angular/src/lib/legacy/core/core.module.ts
@@ -16,7 +16,7 @@ import { KeycloakBearerInterceptor } from './interceptors/keycloak-bearer.interc
 /**
  * @deprecated NgModules are deprecated in Keycloak Angular and will be removed in future versions.
  * Use the new `provideKeycloak` function to load Keycloak in an Angular application.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 @NgModule({
   imports: [CommonModule],

--- a/projects/keycloak-angular/src/lib/legacy/core/interceptors/keycloak-bearer.interceptor.ts
+++ b/projects/keycloak-angular/src/lib/legacy/core/interceptors/keycloak-bearer.interceptor.ts
@@ -23,7 +23,7 @@ import { ExcludedUrlRegex } from '../interfaces/keycloak-options';
  *
  * @deprecated KeycloakBearerInterceptor is deprecated and will be removed in future versions.
  * Use the new functional interceptor such as `includeBearerTokenInterceptor`.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 @Injectable()
 export class KeycloakBearerInterceptor implements HttpInterceptor {

--- a/projects/keycloak-angular/src/lib/legacy/core/interfaces/keycloak-event.ts
+++ b/projects/keycloak-angular/src/lib/legacy/core/interfaces/keycloak-event.ts
@@ -14,7 +14,7 @@
  * will be removed in future versions.
  * Use the new `KEYCLOAK_EVENT_SIGNAL` injection token to listen for the keycloak
  * events.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 export enum KeycloakEventTypeLegacy {
   /**
@@ -62,7 +62,7 @@ export enum KeycloakEventTypeLegacy {
  * will be removed in future versions.
  * Use the new `KEYCLOAK_EVENT_SIGNAL` injection token to listen for the keycloak
  * events.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 export interface KeycloakEventLegacy {
   /**

--- a/projects/keycloak-angular/src/lib/legacy/core/interfaces/keycloak-options.ts
+++ b/projects/keycloak-angular/src/lib/legacy/core/interfaces/keycloak-options.ts
@@ -13,7 +13,7 @@ import { HttpRequest } from '@angular/common/http';
  *
  * @deprecated KeycloakBearerInterceptor is deprecated and will be removed in future versions.
  * Use the new functional interceptor `includeBearerTokenInterceptor`.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 export type HttpMethodsLegacy = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
 
@@ -37,7 +37,7 @@ export type HttpMethodsLegacy = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'OPTIONS' | 
  *
  * @deprecated KeycloakBearerInterceptor is deprecated and will be removed in future versions.
  * Use the new functional interceptor `includeBearerTokenInterceptor`.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 export interface ExcludedUrl {
   url: string;
@@ -51,7 +51,7 @@ export interface ExcludedUrl {
  *
  * @deprecated KeycloakBearerInterceptor is deprecated and will be removed in future versions.
  * Use the new functional interceptor `includeBearerTokenInterceptor`.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 export interface ExcludedUrlRegex {
   urlPattern: RegExp;
@@ -63,7 +63,7 @@ export interface ExcludedUrlRegex {
  *
  * @deprecated KeycloakService is deprecated and will be removed in future versions.
  * Use the new `provideKeycloak` method to load Keycloak in an Angular application.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 export interface KeycloakOptions {
   /**

--- a/projects/keycloak-angular/src/lib/legacy/core/services/keycloak-auth-guard.ts
+++ b/projects/keycloak-angular/src/lib/legacy/core/services/keycloak-auth-guard.ts
@@ -18,7 +18,7 @@ import { KeycloakService } from './keycloak.service';
  *
  * @deprecated Class based guards are deprecated in Keycloak Angular and will be removed in future versions.
  * Use the new `createAuthGuard` function to create a Guard for your application.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 export abstract class KeycloakAuthGuard implements CanActivate {
   /**

--- a/projects/keycloak-angular/src/lib/legacy/core/services/keycloak.service.ts
+++ b/projects/keycloak-angular/src/lib/legacy/core/services/keycloak.service.ts
@@ -25,7 +25,7 @@ import { KeycloakEventLegacy, KeycloakEventTypeLegacy } from '../interfaces/keyc
  *
  * @deprecated This service is deprecated and will be removed in future versions.
  * Use the new `provideKeycloak` function to load Keycloak in an Angular application.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 @Injectable()
 export class KeycloakService {

--- a/projects/keycloak-angular/src/lib/legacy/keycloak-angular.module.ts
+++ b/projects/keycloak-angular/src/lib/legacy/keycloak-angular.module.ts
@@ -13,7 +13,7 @@ import { CoreModule } from './core/core.module';
 /**
  * @deprecated NgModules are deprecated in Keycloak Angular and will be removed in future versions.
  * Use the new `provideKeycloak` function to load Keycloak in an Angular application.
- * More info: https://github.com/mauriciovigolo/keycloak-angular/docs/migration-guides/v19.md
+ * More info: https://github.com/mauriciovigolo/keycloak-angular/blob/main/docs/migration-guides/v19.md
  */
 @NgModule({
   imports: [CoreModule]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [X] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features)
* [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When you click on the migration guide link in the docstring it returns a 404.

## What is the new behavior?

Fix URL in docstrings in the legacy folder to properly include the `/blob/main/` path segment.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
