### PR TITLE
fix(kaHasRoles): re-render on token refresh and auth events

### DIFF
--- a/projects/keycloak-angular/src/lib/directives/has-roles.directive.spec.ts
+++ b/projects/keycloak-angular/src/lib/directives/has-roles.directive.spec.ts
@@ -112,4 +112,31 @@ describe('HasRolesDirective', () => {
       expect(mockKeycloak.hasRealmRole).not.toHaveBeenCalled();
     });
   });
+
+  it('should clear the view on Keycloak logOut', () => {
+    keycloakSignal.and.returnValue({ type: KeycloakEventType.AuthLogout });
+
+    TestBed.runInInjectionContext(() => {
+      const directive = TestBed.inject(HasRolesDirective);
+      directive['render']();
+  
+      expect(mockViewContainerRef.clear).toHaveBeenCalled();
+    });
+  });
+
+  it('should re-render on TokenExpired', () => {
+    keycloakSignal.and.returnValue({ type: KeycloakEventType.TokenExpired });
+
+    mockKeycloak.hasRealmRole.and.returnValue(true);
+
+    TestBed.runInInjectionContext(() => {
+      const directive = TestBed.inject(HasRolesDirective);
+      directive.roles = ['editor'];
+      directive.checkRealm = true;
+
+      directive['render']();
+
+      expect(mockViewContainerRef.createEmbeddedView).toHaveBeenCalledWith(mockTemplateRef);
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `*kaHasRoles` directive currently listens only to the Ready Keycloak event.
As a result, role-based UI visibility is not updated when the access token is refreshed.

This patch enhances the directive to also respond to `AuthRefreshSuccess`, `AuthSuccess`, `TokenExpired`, and `AuthLogout events`.
This ensures that UI elements controlled by `*kaHasRoles` are correctly re-evaluated after authentication or token lifecycle events.

Issue Number: N/A

## What is the new behavior?

`*kaHasRoles` directive now listen `AuthRefreshSuccess`, `AuthSuccess`, `TokenExpired`, and `AuthLogout events`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
Tested in Angular 19.2 app keycloak-js 26 and Keycloak 26