### PR TITLE
test(auto-refresh-token): fix loginOptions in login inactivity test

### DIFF
--- a/projects/keycloak-angular/src/lib/services/auto-refresh-token.service.spec.ts
+++ b/projects/keycloak-angular/src/lib/services/auto-refresh-token.service.spec.ts
@@ -96,7 +96,7 @@ describe('AutoRefreshTokenService', () => {
 
     it('should login if user is inactive and inactivity timeout is set to "login"', async () => {
       service['options'].onInactivityTimeout = 'login';
-      service['options'].logoutOptions = { redirectUri: 'testLoginUri' };
+      service['options'].loginOptions = { redirectUri: 'testLoginUri' };
       mockKeycloak.authenticated = true;
       mockUserActivityService.isActive.and.returnValue(false);
       mockKeycloak.login.and.returnValue(Promise.resolve());


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our [guidelines](https://github.com/mauriciovigolo/keycloak-angular/blob/main/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Test-only fix
```

## What is the current behavior?

A unit test in AutoRefreshTokenService's spec incorrectly assigns logoutOptions in the "login" inactivity timeout test, causing an expectation failure because mockKeycloak.login is invoked with undefined.

Issue Number: N/A

## What is the new behavior?

Correct the test to set loginOptions: { redirectUri: 'testLoginUri' } for the "login" inactivity timeout case.
The test now verifies that mockKeycloak.login is called with the expected options.
No production code changes.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information