### PR TITLE
Align keycloak typings

### DIFF
--- a/projects/keycloak-angular/src/lib/provide-keycloak.spec.ts
+++ b/projects/keycloak-angular/src/lib/provide-keycloak.spec.ts
@@ -56,6 +56,19 @@ describe('provideKeycloak', () => {
     expect(keycloak.didInitialize).toBeFalse();
   });
 
+  it('should instantiate keycloak with a string URL config', () => {
+    const config = '/keycloak.json';
+
+    TestBed.configureTestingModule({
+      providers: [provideKeycloak({ config })]
+    });
+
+    const keycloak = TestBed.inject(Keycloak);
+
+    expect(keycloak).toBeDefined();
+    expect(keycloak.didInitialize).toBeFalse();
+  });
+
   it('should instantiate keycloak and be able to initialize the instance later', () => {
     const config: KeycloakConfig = {
       url: 'kc-server-url',

--- a/projects/keycloak-angular/src/lib/provide-keycloak.ts
+++ b/projects/keycloak-angular/src/lib/provide-keycloak.ts
@@ -24,9 +24,11 @@ import { KeycloakFeature } from './features/keycloak.feature';
  */
 export type ProvideKeycloakOptions = {
   /**
-   * Keycloak configuration, including the server URL, realm, and client ID.
+   * Keycloak configuration. Can be either a KeycloakConfig object with
+   * the server URL, realm, and client ID, or a string URL pointing to
+   * a keycloak.json configuration file (e.g., '/keycloak.json').
    */
-  config: KeycloakConfig;
+  config: KeycloakConfig | string;
 
   /**
    * Optional initialization options for the Keycloak instance.
@@ -82,7 +84,8 @@ const provideKeycloakInAppInitializer = (
  * In such cases, the application must call `keycloak.init()` explicitly.
  *
  * @param options - Configuration object for Keycloak:
- *   - `config`: The Keycloak configuration, including the server URL, realm, and client ID.
+ *   - `config`: The Keycloak configuration. Can be either a KeycloakConfig object with
+ *     url, realm, and clientId, or a string URL pointing to a keycloak.json file.
  *   - `initOptions` (Optional): Initialization options for the Keycloak instance.
  *   - `providers` (Optional): Additional Angular providers to include.
  *   - `features` (Optional): Keycloak Angular features to configure during initialization.
@@ -91,23 +94,24 @@ const provideKeycloakInAppInitializer = (
  *
  * @example
  * ```ts
- * import { provideKeycloak } from './keycloak.providers';
- * import { bootstrapApplication } from '@angular/platform-browser';
- * import { AppComponent } from './app/app.component';
+ * // Using a KeycloakConfig object
+ * provideKeycloak({
+ *   config: {
+ *     url: 'https://auth-server.example.com',
+ *     realm: 'my-realm',
+ *     clientId: 'my-client',
+ *   },
+ *   initOptions: {
+ *     onLoad: 'login-required',
+ *   },
+ * });
  *
- * bootstrapApplication(AppComponent, {
- *   providers: [
- *     provideKeycloak({
- *       config: {
- *         url: 'https://auth-server.example.com',
- *         realm: 'my-realm',
- *         clientId: 'my-client',
- *       },
- *       initOptions: {
- *         onLoad: 'login-required',
- *       },
- *     }),
- *   ],
+ * // Using a string URL to a keycloak.json file
+ * provideKeycloak({
+ *   config: '/keycloak.json',
+ *   initOptions: {
+ *     onLoad: 'login-required',
+ *   },
  * });
  * ```
  */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added
* [x] Docs have been added / updated

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The current typings for `provideKeycloak` do not allow passing a string URL as the `config` value, even though this usage is supported at runtime.

Issue Number: #657

## What is the new behavior?

Updates the typings to allow string URLs to be used as the `config` value in `provideKeycloak`, for example:

```ts
provideKeycloak({ config: '/keycloak.json' });
```

Adds/updates tests to cover this behavior.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

This change aligns the typings with the existing runtime behavior.
